### PR TITLE
Allow GET requests for Netlify function tests

### DIFF
--- a/NETLIFY_SETUP.md
+++ b/NETLIFY_SETUP.md
@@ -31,13 +31,11 @@ The backend functions require the environment variables listed below to communic
     | ----------------------------------- | -------------------------------------------------------------------------------------------------------- | ------------------------------ |
     | `SUPABASE_URL`                      | The project URL from your Supabase dashboard (Settings > API).                                           | `https://xyz.supabase.co`      |
     | `SUPABASE_ANON_KEY`                 | The public anonymous key from your Supabase dashboard (Settings > API).                                  | `ey...`                        |
-    | `GEMINI_API_KEY`                    | Your API key from Google AI Studio.                                                                      | `AIza...`                      |
+    | `GEMINI_API_KEY`                    | Your API key from Google AI Studio (used for Gemini and Google Cloud Vision).                                                                      | `AIza...`                      |
     | `STRIPE_SECRET_KEY`                 | Your Stripe secret key (use a test key for development/staging).                                         | `sk_test_...`                  |
     | `BREVO_API_KEY`                     | Your API v3 key from the Brevo dashboard (SMTP & API section).                                           | `xkeysib...`                   |
     | `TEST_EMAIL_RECIPIENT`              | The email address where the Brevo test email will be sent.                                               | `your-email@example.com`       |
     | `TEST_EMAIL_SENDER`                 | An authenticated sender email address in your Brevo account.                                             | `noreply@yourdomain.com`       |
-    | `GOOGLE_APPLICATION_CREDENTIALS`    | **(For Google Cloud Vision)** The content of your service account JSON file. Paste the entire JSON here. | `{"type": "service_account",...}` |
-
 5.  **Redeploy:**
     *   After adding all the variables, you'll need to trigger a new deployment for the changes to take effect.
     *   Go to the "Deploys" tab for your site.

--- a/netlify/functions/test-brevo.ts
+++ b/netlify/functions/test-brevo.ts
@@ -5,10 +5,10 @@ import { Handler } from '@netlify/functions';
 import * as SibApiV3Sdk from '@getbrevo/brevo';
 
 export const handler: Handler = async (event) => {
-  if (event.httpMethod !== 'POST') {
-    return { 
-      statusCode: 405, 
-      body: JSON.stringify({ success: false, error: 'Method Not Allowed' }) 
+  if (event.httpMethod !== 'POST' && event.httpMethod !== 'GET') {
+    return {
+      statusCode: 405,
+      body: JSON.stringify({ success: false, error: `Method ${event.httpMethod} not allowed. Use GET or POST.` })
     };
   }
 

--- a/netlify/functions/test-gemini.ts
+++ b/netlify/functions/test-gemini.ts
@@ -5,10 +5,10 @@ import { Handler } from '@netlify/functions';
 import { GoogleGenAI } from '@google/genai';
 
 export const handler: Handler = async (event) => {
-  if (event.httpMethod !== 'POST') {
-    return { 
-      statusCode: 405, 
-      body: JSON.stringify({ success: false, error: 'Method Not Allowed' }) 
+  if (event.httpMethod !== 'POST' && event.httpMethod !== 'GET') {
+    return {
+      statusCode: 405,
+      body: JSON.stringify({ success: false, error: `Method ${event.httpMethod} not allowed. Use GET or POST.` })
     };
   }
 

--- a/netlify/functions/test-stripe.ts
+++ b/netlify/functions/test-stripe.ts
@@ -5,10 +5,10 @@ import { Handler } from '@netlify/functions';
 import Stripe from 'stripe';
 
 export const handler: Handler = async (event) => {
-  if (event.httpMethod !== 'POST') {
-    return { 
-      statusCode: 405, 
-      body: JSON.stringify({ success: false, error: 'Method Not Allowed' }) 
+  if (event.httpMethod !== 'POST' && event.httpMethod !== 'GET') {
+    return {
+      statusCode: 405,
+      body: JSON.stringify({ success: false, error: `Method ${event.httpMethod} not allowed. Use GET or POST.` })
     };
   }
 

--- a/netlify/functions/test-supabase.ts
+++ b/netlify/functions/test-supabase.ts
@@ -5,10 +5,10 @@ import { Handler } from '@netlify/functions';
 import { createClient } from '@supabase/supabase-js';
 
 export const handler: Handler = async (event) => {
-  if (event.httpMethod !== 'POST') {
-    return { 
-      statusCode: 405, 
-      body: JSON.stringify({ success: false, error: 'Method Not Allowed' }) 
+  if (event.httpMethod !== 'POST' && event.httpMethod !== 'GET') {
+    return {
+      statusCode: 405,
+      body: JSON.stringify({ success: false, error: `Method ${event.httpMethod} not allowed. Use GET or POST.` })
     };
   }
 
@@ -27,17 +27,18 @@ export const handler: Handler = async (event) => {
   try {
     const supabase = createClient(SUPABASE_URL, SUPABASE_ANON_KEY);
     
-    // Perform a minimal, read-only test.
-    // NOTE: This will fail if you don't have a table named 'your_table_name'. 
-    // This is just for a connection test; a better test would be to query a real, public table.
+    // Perform a minimal, read-only test against a placeholder table.
+    // It's expected that the table 'your_table_name' does not exist.
     const { data, error } = await supabase
       .from('your_table_name')
       .select('id')
       .limit(1);
 
-    // It's common for this query to fail if the table doesn't exist.
-    // We can consider the connection a success if the error is about the table, not authentication.
-    if (error && !error.message.includes('relation "your_table_name" does not exist')) {
+    const missingTable =
+      error?.message.includes('relation "your_table_name" does not exist') ||
+      error?.message.includes("Could not find the table 'public.your_table_name'");
+
+    if (error && !missingTable) {
       throw error;
     }
 
@@ -47,7 +48,9 @@ export const handler: Handler = async (event) => {
         success: true,
         data: {
           message: 'Successfully connected to Supabase.',
-          result: error ? `Query failed as expected (table not found), but connection was successful.` : data,
+          result: missingTable
+            ? 'Query failed as expected (table not found), but connection was successful.'
+            : data,
         },
       }),
     };


### PR DESCRIPTION
## Summary
- allow GET or POST for Netlify test functions
- permit generate-story function to accept prompt via GET query
- treat missing Supabase test table as a successful connection
- use GEMINI_API_KEY for Google Cloud Vision test and update docs

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68c4fcf8bb4c83309c8a6b4283c6e064