### PR TITLE
chore: configure netlify deployment

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+node_modules/
+dist/

--- a/api/test-supabase.ts
+++ b/api/test-supabase.ts
@@ -28,17 +28,16 @@ export default async function handler(req: IncomingMessage, res: ApiResponse) {
   try {
     const supabase = createClient(SUPABASE_URL, SUPABASE_ANON_KEY);
     
-    // Perform a minimal, read-only test.
-    // NOTE: This will fail if you don't have a table named 'your_table_name'. 
-    // This is just for a connection test; a better test would be to query a real, public table.
+    // Perform a minimal, read-only test by querying a table that is expected not to exist.
+    // Any "table not found" error indicates that the connection and credentials are valid.
     const { data, error } = await supabase
       .from('your_table_name')
       .select('id')
       .limit(1);
 
-    // It's common for this query to fail if the table doesn't exist.
-    // We can consider the connection a success if the error is about the table, not authentication.
-    if (error && !error.message.includes('relation "your_table_name" does not exist')) {
+    const tableMissing =
+      error && /relation "your_table_name" does not exist|Could not find the table/i.test(error.message);
+    if (error && !tableMissing) {
       throw error;
     }
 

--- a/netlify.toml
+++ b/netlify.toml
@@ -1,0 +1,16 @@
+[build]
+  command = "npm run build"
+  publish = "dist"
+  functions = "netlify/functions"
+
+[build.environment]
+  NODE_VERSION = "20"
+
+[functions]
+  node_bundler = "esbuild"
+
+[[redirects]]
+  from = "/api/*"
+  to = "/.netlify/functions/:splat"
+  status = 200
+

--- a/netlify/functions/test-supabase.ts
+++ b/netlify/functions/test-supabase.ts
@@ -27,17 +27,16 @@ export const handler: Handler = async (event) => {
   try {
     const supabase = createClient(SUPABASE_URL, SUPABASE_ANON_KEY);
     
-    // Perform a minimal, read-only test.
-    // NOTE: This will fail if you don't have a table named 'your_table_name'. 
-    // This is just for a connection test; a better test would be to query a real, public table.
+    // Perform a minimal, read-only test by querying a table that is expected not to exist.
+    // Any "table not found" error indicates that the connection and credentials are valid.
     const { data, error } = await supabase
       .from('your_table_name')
       .select('id')
       .limit(1);
 
-    // It's common for this query to fail if the table doesn't exist.
-    // We can consider the connection a success if the error is about the table, not authentication.
-    if (error && !error.message.includes('relation "your_table_name" does not exist')) {
+    const tableMissing =
+      error && /relation "your_table_name" does not exist|Could not find the table/i.test(error.message);
+    if (error && !tableMissing) {
       throw error;
     }
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -17,6 +17,6 @@
     "jsx": "react-jsx"
   },
   "include": ["**/*.ts", "**/*.tsx"],
-  "exclude": ["vite.config.ts"],
+  "exclude": ["vite.config.ts", "netlify", "api"],
   "references": [{ "path": "./tsconfig.node.json" }]
 }


### PR DESCRIPTION
## Summary
- add Netlify build config with Node 20 and API redirects
- exclude serverless code from TypeScript build
- ignore build and dependency directories
- handle missing Supabase test table as a successful connection

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68c4f64cffac83309e54c40665d11c86