### PR TITLE
refactor: centralize HTTP method check

### DIFF
--- a/netlify/functions/generate-story.ts
+++ b/netlify/functions/generate-story.ts
@@ -2,6 +2,7 @@
 // File path: /netlify/functions/generate-story.ts
 import { Handler } from '@netlify/functions';
 import { GoogleGenAI } from '@google/genai';
+import { ensureMethod } from './utils/ensureMethod';
 
 /**
  * Converts an async iterator (like the one from Gemini's SDK) into a Web-standard ReadableStream.
@@ -39,11 +40,9 @@ async function* generateGeminiStream(prompt: string, apiKey: string) {
 }
 
 export const handler: Handler = async (event) => {
-  if (event.httpMethod !== 'POST' && event.httpMethod !== 'GET') {
-    return {
-      statusCode: 405,
-      body: JSON.stringify({ success: false, error: `Method ${event.httpMethod} not allowed. Use GET or POST.` }),
-    };
+  const methodNotAllowed = ensureMethod(event, 'POST', 'GET');
+  if (methodNotAllowed) {
+    return methodNotAllowed;
   }
 
   const { GEMINI_API_KEY } = process.env;

--- a/netlify/functions/test-brevo.ts
+++ b/netlify/functions/test-brevo.ts
@@ -3,13 +3,12 @@
 
 import { Handler } from '@netlify/functions';
 import * as SibApiV3Sdk from '@getbrevo/brevo';
+import { ensureMethod } from './utils/ensureMethod';
 
 export const handler: Handler = async (event) => {
-  if (event.httpMethod !== 'POST' && event.httpMethod !== 'GET') {
-    return {
-      statusCode: 405,
-      body: JSON.stringify({ success: false, error: `Method ${event.httpMethod} not allowed. Use GET or POST.` })
-    };
+  const methodNotAllowed = ensureMethod(event, 'POST', 'GET');
+  if (methodNotAllowed) {
+    return methodNotAllowed;
   }
 
   const { BREVO_API_KEY, TEST_EMAIL_RECIPIENT, TEST_EMAIL_SENDER } = process.env;

--- a/netlify/functions/test-gemini.ts
+++ b/netlify/functions/test-gemini.ts
@@ -3,13 +3,12 @@
 
 import { Handler } from '@netlify/functions';
 import { GoogleGenAI } from '@google/genai';
+import { ensureMethod } from './utils/ensureMethod';
 
 export const handler: Handler = async (event) => {
-  if (event.httpMethod !== 'POST' && event.httpMethod !== 'GET') {
-    return {
-      statusCode: 405,
-      body: JSON.stringify({ success: false, error: `Method ${event.httpMethod} not allowed. Use GET or POST.` })
-    };
+  const methodNotAllowed = ensureMethod(event, 'POST', 'GET');
+  if (methodNotAllowed) {
+    return methodNotAllowed;
   }
 
   const { GEMINI_API_KEY } = process.env;

--- a/netlify/functions/test-google-cloud-vision.ts
+++ b/netlify/functions/test-google-cloud-vision.ts
@@ -2,13 +2,12 @@
 // File path: /netlify/functions/test-google-cloud-vision.ts
 
 import { Handler } from '@netlify/functions';
+import { ensureMethod } from './utils/ensureMethod';
 
 export const handler: Handler = async (event) => {
-  if (event.httpMethod !== 'POST' && event.httpMethod !== 'GET') {
-    return {
-      statusCode: 405,
-      body: JSON.stringify({ success: false, error: `Method ${event.httpMethod} not allowed. Use GET or POST.` })
-    };
+  const methodNotAllowed = ensureMethod(event, 'POST', 'GET');
+  if (methodNotAllowed) {
+    return methodNotAllowed;
   }
 
   const { GEMINI_API_KEY } = process.env;

--- a/netlify/functions/test-stripe.ts
+++ b/netlify/functions/test-stripe.ts
@@ -3,13 +3,12 @@
 
 import { Handler } from '@netlify/functions';
 import Stripe from 'stripe';
+import { ensureMethod } from './utils/ensureMethod';
 
 export const handler: Handler = async (event) => {
-  if (event.httpMethod !== 'POST' && event.httpMethod !== 'GET') {
-    return {
-      statusCode: 405,
-      body: JSON.stringify({ success: false, error: `Method ${event.httpMethod} not allowed. Use GET or POST.` })
-    };
+  const methodNotAllowed = ensureMethod(event, 'POST', 'GET');
+  if (methodNotAllowed) {
+    return methodNotAllowed;
   }
 
   const { STRIPE_SECRET_KEY } = process.env;

--- a/netlify/functions/test-supabase.ts
+++ b/netlify/functions/test-supabase.ts
@@ -3,13 +3,12 @@
 
 import { Handler } from '@netlify/functions';
 import { createClient } from '@supabase/supabase-js';
+import { ensureMethod } from './utils/ensureMethod';
 
 export const handler: Handler = async (event) => {
-  if (event.httpMethod !== 'POST' && event.httpMethod !== 'GET') {
-    return {
-      statusCode: 405,
-      body: JSON.stringify({ success: false, error: `Method ${event.httpMethod} not allowed. Use GET or POST.` })
-    };
+  const methodNotAllowed = ensureMethod(event, 'POST', 'GET');
+  if (methodNotAllowed) {
+    return methodNotAllowed;
   }
 
   const { SUPABASE_URL, SUPABASE_ANON_KEY } = process.env;

--- a/netlify/functions/utils/ensureMethod.ts
+++ b/netlify/functions/utils/ensureMethod.ts
@@ -1,0 +1,24 @@
+import { HandlerEvent, HandlerResponse } from '@netlify/functions';
+
+/**
+ * Ensures the incoming request uses an allowed HTTP method.
+ *
+ * @param event - The Netlify handler event containing the HTTP method.
+ * @param allowedMethods - List of permitted HTTP methods (e.g., 'GET', 'POST').
+ * @returns A 405 response if the method is not allowed; otherwise, undefined.
+ */
+export function ensureMethod(
+  event: HandlerEvent,
+  ...allowedMethods: string[]
+): HandlerResponse | undefined {
+  if (!allowedMethods.includes(event.httpMethod)) {
+    const allowed = allowedMethods.join(' or ');
+    return {
+      statusCode: 405,
+      body: JSON.stringify({
+        success: false,
+        error: `Method ${event.httpMethod} not allowed. Use ${allowed}.`,
+      }),
+    };
+  }
+}


### PR DESCRIPTION
## Summary
- add reusable `ensureMethod` helper to validate allowed HTTP methods
- refactor Netlify functions to use `ensureMethod` instead of inline checks

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68c5ab08dc108330b23ba47b29669112