### PR TITLE
Allow Stripe API version configuration

### DIFF
--- a/NETLIFY_SETUP.md
+++ b/NETLIFY_SETUP.md
@@ -12,33 +12,35 @@ The backend functions require the environment variables listed below to communic
 
 ## Configuration Steps
 
-1.  **Navigate to your Site:**
-    *   Log in to your Netlify account.
-    *   Go to the "Sites" section and select the site you've deployed from this repository.
+1. **Navigate to your Site:**
+   * Log in to your Netlify account.
+   * Go to the "Sites" section and select the site you've deployed from this repository.
 
-2.  **Go to Site Configuration:**
-    *   From your site's overview page, click on "Site configuration".
+2. **Go to Site Configuration:**
+   * From your site's overview page, click on "Site configuration".
 
-3.  **Find Environment Variables:**
-    *   In the sidebar, navigate to "Environment variables".
+3. **Find Environment Variables:**
+   * In the sidebar, navigate to "Environment variables".
 
-4.  **Add Environment Variables:**
-    *   Click "Add a variable" and select "Create a new variable".
-    *   Add each key-value pair one by one. For sensitive keys, it's highly recommended to use Netlify's "Secret" value type, although standard variables also work.
-    *   Add the following variables with their corresponding values from your service provider dashboards:
+4. **Add Environment Variables:**
+   * Click "Add a variable" and select "Create a new variable".
+   * Add each key-value pair one by one. For sensitive keys, it's highly recommended to use Netlify's "Secret" value type, although standard variables also work.
+   * Add the following variables with their corresponding values from your service provider dashboards:
 
-    | Variable Name                       | Description                                                                                              | Example Value                  |
-    | ----------------------------------- | -------------------------------------------------------------------------------------------------------- | ------------------------------ |
-    | `SUPABASE_URL`                      | The project URL from your Supabase dashboard (Settings > API).                                           | `https://xyz.supabase.co`      |
-    | `SUPABASE_ANON_KEY`                 | The public anonymous key from your Supabase dashboard (Settings > API).                                  | `ey...`                        |
-    | `GEMINI_API_KEY`                    | Your API key from Google AI Studio (used for Gemini and Google Cloud Vision).                                                                      | `AIza...`                      |
-    | `STRIPE_SECRET_KEY`                 | Your Stripe secret key (use a test key for development/staging).                                         | `sk_test_...`                  |
-    | `BREVO_API_KEY`                     | Your API v3 key from the Brevo dashboard (SMTP & API section).                                           | `xkeysib...`                   |
-    | `TEST_EMAIL_RECIPIENT`              | The email address where the Brevo test email will be sent.                                               | `your-email@example.com`       |
-    | `TEST_EMAIL_SENDER`                 | An authenticated sender email address in your Brevo account.                                             | `noreply@yourdomain.com`       |
-5.  **Redeploy:**
-    *   After adding all the variables, you'll need to trigger a new deployment for the changes to take effect.
-    *   Go to the "Deploys" tab for your site.
-    *   Click the "Trigger deploy" dropdown and select "Deploy site".
+   | Variable Name          | Description                                                                 | Example Value             |
+   | ---------------------- | --------------------------------------------------------------------------- | ------------------------- |
+   | `SUPABASE_URL`         | The project URL from your Supabase dashboard (Settings > API).             | `https://xyz.supabase.co` |
+   | `SUPABASE_ANON_KEY`    | The public anonymous key from your Supabase dashboard (Settings > API).    | `ey...`                   |
+   | `GEMINI_API_KEY`       | Your API key from Google AI Studio (used for Gemini and Google Cloud Vision). | `AIza...`                 |
+   | `STRIPE_SECRET_KEY`    | Your Stripe secret key (use a test key for development/staging).           | `sk_test_...`             |
+   | `STRIPE_API_VERSION`   | Optional Stripe API version. Defaults to `2024-08-20` when not set.         | `2024-08-20`              |
+   | `BREVO_API_KEY`        | Your API v3 key from the Brevo dashboard (SMTP & API section).             | `xkeysib...`              |
+   | `TEST_EMAIL_RECIPIENT` | The email address where the Brevo test email will be sent.                 | `your-email@example.com`  |
+   | `TEST_EMAIL_SENDER`    | An authenticated sender email address in your Brevo account.               | `noreply@yourdomain.com`  |
+
+5. **Redeploy:**
+   * After adding all the variables, you'll need to trigger a new deployment for the changes to take effect.
+   * Go to the "Deploys" tab for your site.
+   * Click the "Trigger deploy" dropdown and select "Deploy site".
 
 Your backend functions will now have access to these keys via `process.env.VARIABLE_NAME`.

--- a/netlify/functions/test-stripe.ts
+++ b/netlify/functions/test-stripe.ts
@@ -11,7 +11,7 @@ export const handler: Handler = async (event) => {
     return methodNotAllowed;
   }
 
-  const { STRIPE_SECRET_KEY } = process.env;
+  const { STRIPE_SECRET_KEY, STRIPE_API_VERSION } = process.env;
 
   if (!STRIPE_SECRET_KEY) {
     return {
@@ -24,9 +24,11 @@ export const handler: Handler = async (event) => {
   }
   
   try {
+    const apiVersion =
+      (STRIPE_API_VERSION as Stripe.LatestApiVersion | undefined) || '2024-08-20';
+
     const stripe = new Stripe(STRIPE_SECRET_KEY, {
-      // Fix: Update Stripe API version to match the required type from the SDK.
-      apiVersion: '2025-08-27.basil', 
+      apiVersion,
     });
 
     // A safe, read-only operation to test the API key


### PR DESCRIPTION
## Summary
- read Stripe API version from `STRIPE_API_VERSION` env var with default `2024-08-20`
- document `STRIPE_API_VERSION` in Netlify setup instructions

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68c5abf8d5c083308276a0daa119414c