### PR TITLE
Allow Stripe API version configuration and stabilize landing page

### DIFF
--- a/LandingPage.tsx
+++ b/LandingPage.tsx
@@ -1,13 +1,95 @@
-import React, { useState, useEffect } from 'react';
+import React, { useState, useEffect, useRef } from 'react';
 import Spinner from './components/Spinner';
 import Logo from './components/Logo';
-import { createClient } from '@supabase/supabase-js';
 import { runOcr, OcrResult } from './integrations/googleVision';
 import { analyzeWithGemini, GeminiAnalysis } from './integrations/gemini';
+import supabaseBrowser from './lib/supabase-browser';
 
-const supabaseUrl = (import.meta as any).env.VITE_SUPABASE_URL as string;
-const supabaseAnonKey = (import.meta as any).env.VITE_SUPABASE_ANON_KEY as string;
-const supabase = createClient(supabaseUrl, supabaseAnonKey);
+// Debug helper for fetch calls – easy to remove later
+async function fetchWithReport(input: RequestInfo | URL, init?: RequestInit) {
+  const url = typeof input === 'string' ? input : (input as URL).toString();
+  const started = Date.now();
+  try {
+    const res = await fetch(input, init);
+    console.table([
+      {
+        url,
+        method: init?.method ?? 'GET',
+        status: res.status,
+        ok: res.ok,
+        time_ms: Date.now() - started,
+      },
+    ]);
+    if (!res.ok) {
+      const text = await res.text().catch(() => '<body read failed>');
+      console.warn('Response body preview:', text.slice(0, 200));
+    }
+    return res;
+  } catch (err: any) {
+    console.error('Failed to fetch', {
+      url,
+      message: err?.message,
+      time_ms: Date.now() - started,
+    });
+    throw err;
+  }
+}
+
+async function loadDropdownData() {
+  const sb = supabaseBrowser;
+  if (!sb) {
+    return {
+      intendedUses: [] as string[],
+      languages: [] as string[],
+      tiers: [] as string[],
+      certTypes: [] as string[],
+      error: 'Supabase is not configured. Set VITE_SUPABASE_URL and VITE_SUPABASE_ANON_KEY.',
+    };
+  }
+  try {
+    const { data: langRows, error: langError } = await sb
+      .from('languages')
+      .select('languagename');
+    const { data: tierRows, error: tierError } = await sb
+      .from('tiers')
+      .select('tier');
+    const { data: certRows, error: certError } = await sb
+      .from('certificationtypes')
+      .select('certtype');
+    const { data: useRows, error: useError } = await sb
+      .from('certificationmap')
+      .select('intendeduse');
+
+    const languages = Array.from(
+      new Set((langRows ?? []).map((l: any) => l.languagename).filter(Boolean))
+    ).sort();
+    const tiers = Array.from(
+      new Set((tierRows ?? []).map((t: any) => t.tier).filter(Boolean))
+    ).sort();
+    const certTypes = Array.from(
+      new Set((certRows ?? []).map((c: any) => c.certtype).filter(Boolean))
+    ).sort();
+    const intendedUses = Array.from(
+      new Set((useRows ?? []).map((u: any) => u.intendeduse).filter(Boolean))
+    ).sort();
+
+    const error =
+      langError?.message ||
+      tierError?.message ||
+      certError?.message ||
+      useError?.message;
+
+    return { languages, tiers, certTypes, intendedUses, error };
+  } catch (err) {
+    return {
+      languages: [] as string[],
+      tiers: [] as string[],
+      certTypes: [] as string[],
+      intendedUses: [] as string[],
+      error: err instanceof Error ? err.message : 'Unknown error',
+    };
+  }
+}
 
 type Screen = 'form' | 'waiting' | 'result' | 'error';
 
@@ -30,12 +112,19 @@ const LandingPage: React.FC = () => {
   const [customerEmail, setCustomerEmail] = useState('');
   const [customerPhone, setCustomerPhone] = useState('');
   const [intendedUse, setIntendedUse] = useState('');
+  const [certificationType, setCertificationType] = useState('');
+  const [tier, setTier] = useState('');
   const [sourceLanguage, setSourceLanguage] = useState('');
   const [targetLanguage, setTargetLanguage] = useState('');
-  const [files, setFiles] = useState<FileList | null>(null);
+  const [files, setFiles] = useState<File[]>([]);
+  const fileInputRef = useRef<HTMLInputElement | null>(null);
 
   const [intendedUseOptions, setIntendedUseOptions] = useState<string[]>([]);
+  const [certTypeOptions, setCertTypeOptions] = useState<string[]>([]);
+  const [tierOptions, setTierOptions] = useState<string[]>([]);
   const [languageOptions, setLanguageOptions] = useState<string[]>([]);
+  const [loadingDropdowns, setLoadingDropdowns] = useState(true);
+  const [loadError, setLoadError] = useState<string | null>(null);
 
   const [errors, setErrors] = useState<Record<string,string>>({});
   const [screen, setScreen] = useState<Screen>('form');
@@ -43,42 +132,98 @@ const LandingPage: React.FC = () => {
   const [results, setResults] = useState<CombinedFile[]>([]);
   const [errorStep, setErrorStep] = useState('');
   const [menuOpen, setMenuOpen] = useState(false);
+  const menuRef = useRef<HTMLDivElement | null>(null);
 
   useEffect(() => {
-    async function fetchOptions() {
-      const { data: uses } = await supabase.from('CertificationMap').select('intendedUse');
-      const uniqueUses = Array.from(new Set((uses ?? []).map((u: any) => u.intendedUse).filter(Boolean)));
-      setIntendedUseOptions(uniqueUses);
-      const { data: langs } = await supabase.from('Languages').select('name');
-      setLanguageOptions((langs ?? []).map((l: any) => l.name));
-    }
-    fetchOptions();
+    let isMounted = true;
+    setLoadingDropdowns(true);
+    loadDropdownData().then(
+      ({ languages, tiers, certTypes, intendedUses, error }) => {
+        if (!isMounted) return;
+        setLanguageOptions(languages);
+        setTierOptions(tiers);
+        setCertTypeOptions(certTypes);
+        setIntendedUseOptions(intendedUses);
+        if (error) setLoadError(error);
+        setLoadingDropdowns(false);
+      }
+    );
+    return () => {
+      isMounted = false;
+    };
   }, []);
+
+  useEffect(() => {
+    (async () => {
+      try {
+        const url = (import.meta as any).env?.VITE_SUPABASE_URL;
+        const key = (import.meta as any).env?.VITE_SUPABASE_ANON_KEY;
+        console.log('VITE_SUPABASE_URL?', Boolean(url), 'VITE_SUPABASE_ANON_KEY?', Boolean(key));
+
+        const sb = supabaseBrowser;
+        if (!sb) {
+          console.log('Supabase ping: client not initialized');
+          return;
+        }
+
+        const { data, error } = await sb
+          .from('languages')
+          .select('languagename')
+          .limit(1);
+
+        console.log('Supabase ping:', { ok: !error, error: error?.message, sample: data?.[0] });
+      } catch (e: any) {
+        console.error('Supabase ping failed:', e?.message);
+      }
+    })();
+  }, []);
+
+  useEffect(() => {
+    const target = menuRef.current;
+    if (!(target instanceof Node)) return;
+    const mo = new MutationObserver(() => {});
+    mo.observe(target, { childList: true, attributes: true });
+    return () => mo.disconnect();
+  }, [menuOpen]);
 
   const validate = (): boolean => {
     const newErrors: Record<string,string> = {};
     if(!customerName.trim()) newErrors.customerName = 'Name is required';
     if(!customerEmail.match(/^[^\s@]+@[^\s@]+\.[^\s@]+$/)) newErrors.customerEmail = 'Valid email required';
     if(!intendedUse) newErrors.intendedUse = 'Intended use required';
+    if(!certificationType) newErrors.certificationType = 'Certification type required';
+    if(!tier) newErrors.tier = 'Tier required';
     if(!sourceLanguage) newErrors.sourceLanguage = 'Source language required';
     if(!targetLanguage) newErrors.targetLanguage = 'Target language required';
-    if(!files || files.length === 0) newErrors.files = 'At least one file required';
-    if(files){
-      Array.from(files).forEach(f => {
-        const ext = f.name.split('.').pop()?.toLowerCase();
-        if(!ext || !allowedExtensions.includes(ext)){
-          newErrors.files = 'Unsupported file type';
-        }
-      });
-    }
+    if(files.length === 0) newErrors.files = 'At least one file required';
+    files.forEach(f => {
+      const ext = f.name.split('.').pop()?.toLowerCase();
+      if(!ext || !allowedExtensions.includes(ext)){
+        newErrors.files = 'Unsupported file type';
+      }
+    });
     setErrors(newErrors);
     return Object.keys(newErrors).length === 0;
+  };
+
+  const handleFilesChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    setFiles(e.target.files ? Array.from(e.target.files) : []);
+  };
+
+  const removeFile = (name: string) => {
+    setFiles(prev => prev.filter(f => f.name !== name));
+    if (fileInputRef.current) fileInputRef.current.value = '';
+  };
+
+  const removeAllFiles = () => {
+    setFiles([]);
+    if (fileInputRef.current) fileInputRef.current.value = '';
   };
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
     if(!validate()) return;
-    if(!files) return;
+    if(files.length === 0) return;
     try{
       setScreen('waiting');
       setStatusText('Uploading…');
@@ -87,7 +232,7 @@ const LandingPage: React.FC = () => {
 
       setStatusText('Analyzing with OCR…');
       const ocrResults: OcrResult[] = [];
-      for (const file of Array.from(files)) {
+      for (const file of files) {
         const ocr = await runOcr(file.name, file.name);
         ocrResults.push(ocr);
       }
@@ -124,7 +269,7 @@ const LandingPage: React.FC = () => {
     return sum + file.pages.reduce((s,p)=> s + Math.ceil(p.wordCount/250),0);
   },0);
   const perPageRate = 20;
-  const certType = intendedUse || 'Standard';
+  const displayCertType = certificationType || 'Standard';
   const certPrice = 50;
   const finalTotal = perPageRate * totalBillablePages + certPrice;
 
@@ -144,7 +289,7 @@ const LandingPage: React.FC = () => {
           <a href="#" className="px-4 py-2 font-medium hover:underline">Login</a>
         </nav>
         {menuOpen && (
-          <div className="sm:hidden absolute right-4 top-14 bg-white dark:bg-[#0C1E40] shadow rounded">
+          <div ref={menuRef} className="sm:hidden absolute right-4 top-14 bg-white dark:bg-[#0C1E40] shadow rounded">
             <a href="#" className="block px-4 py-2" onClick={()=>setMenuOpen(false)}>Login</a>
           </div>
         )}
@@ -152,7 +297,7 @@ const LandingPage: React.FC = () => {
 
       {/* Content */}
       <main className="flex-1 p-4">
-        {screen === 'form' && (
+        {screen === 'form' && !loadError && (
           <form onSubmit={handleSubmit} className="max-w-2xl mx-auto space-y-4">
             {Object.keys(errors).length > 0 && (
               <div className="bg-red-100 text-red-700 p-2 rounded" role="alert">
@@ -173,22 +318,77 @@ const LandingPage: React.FC = () => {
             </div>
             <div>
               <label className="block font-medium" htmlFor="intendedUse">Intended Use*</label>
-              <select id="intendedUse" value={intendedUse} onChange={e=>setIntendedUse(e.target.value)} aria-invalid={errors.intendedUse ? 'true' : undefined} className="w-full border p-2 rounded">
+              <select
+                id="intendedUse"
+                value={intendedUse}
+                onChange={e=>setIntendedUse(e.target.value)}
+                aria-invalid={errors.intendedUse ? 'true' : undefined}
+                disabled={loadingDropdowns}
+                className="w-full border p-2 rounded"
+              >
                 <option value="">Select...</option>
-                {intendedUseOptions.map(opt => <option key={opt} value={opt}>{opt}</option>)}
+                {intendedUseOptions.map(opt => (
+                  <option key={opt} value={opt}>{opt}</option>
+                ))}
+              </select>
+            </div>
+            <div>
+              <label className="block font-medium" htmlFor="certificationType">Certification Type*</label>
+              <select
+                id="certificationType"
+                value={certificationType}
+                onChange={e=>setCertificationType(e.target.value)}
+                aria-invalid={errors.certificationType ? 'true' : undefined}
+                disabled={loadingDropdowns}
+                className="w-full border p-2 rounded"
+              >
+                <option value="">Select...</option>
+                {certTypeOptions.map(ct => (
+                  <option key={ct} value={ct}>{ct}</option>
+                ))}
+              </select>
+            </div>
+            <div>
+              <label className="block font-medium" htmlFor="tier">Tier*</label>
+              <select
+                id="tier"
+                value={tier}
+                onChange={e=>setTier(e.target.value)}
+                aria-invalid={errors.tier ? 'true' : undefined}
+                disabled={loadingDropdowns}
+                className="w-full border p-2 rounded"
+              >
+                <option value="">Select...</option>
+                {tierOptions.map(t => (
+                  <option key={t} value={t}>{t}</option>
+                ))}
               </select>
             </div>
             <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
               <div>
                 <label className="block font-medium" htmlFor="sourceLanguage">Source Language*</label>
-                <select id="sourceLanguage" value={sourceLanguage} onChange={e=>setSourceLanguage(e.target.value)} aria-invalid={errors.sourceLanguage ? 'true' : undefined} className="w-full border p-2 rounded">
+                <select
+                  id="sourceLanguage"
+                  value={sourceLanguage}
+                  onChange={e=>setSourceLanguage(e.target.value)}
+                  aria-invalid={errors.sourceLanguage ? 'true' : undefined}
+                  disabled={loadingDropdowns}
+                  className="w-full border p-2 rounded"
+                >
                   <option value="">Select...</option>
                   {languageOptions.map(l => <option key={l} value={l}>{l}</option>)}
                 </select>
               </div>
               <div>
                 <label className="block font-medium" htmlFor="targetLanguage">Target Language*</label>
-                <select id="targetLanguage" value={targetLanguage} onChange={e=>setTargetLanguage(e.target.value)} aria-invalid={errors.targetLanguage ? 'true' : undefined} className="w-full border p-2 rounded">
+                <select
+                  id="targetLanguage"
+                  value={targetLanguage}
+                  onChange={e=>setTargetLanguage(e.target.value)}
+                  aria-invalid={errors.targetLanguage ? 'true' : undefined}
+                  disabled={loadingDropdowns}
+                  className="w-full border p-2 rounded"
+                >
                   <option value="">Select...</option>
                   {languageOptions.map(l => <option key={l} value={l}>{l}</option>)}
                 </select>
@@ -196,10 +396,37 @@ const LandingPage: React.FC = () => {
             </div>
             <div>
               <label className="block font-medium" htmlFor="files">Upload Files*</label>
-              <input id="files" type="file" multiple accept=".jpg,.jpeg,.png,.tiff,.doc,.docx,.pdf,.xls,.xlsx" onChange={e=>setFiles(e.target.files)} aria-invalid={errors.files ? 'true' : undefined} className="w-full border p-2 rounded" />
+              <input
+                ref={fileInputRef}
+                id="files"
+                type="file"
+                multiple
+                accept=".jpg,.jpeg,.png,.tiff,.doc,.docx,.pdf,.xls,.xlsx"
+                onChange={handleFilesChange}
+                aria-invalid={errors.files ? 'true' : undefined}
+                className="w-full border p-2 rounded"
+              />
+              {files.length > 0 && (
+                <ul className="mt-2 space-y-1">
+                  {files.map(f => (
+                    <li key={f.name} className="flex items-center justify-between">
+                      <span>{f.name}</span>
+                      <button type="button" className="text-sm text-red-600" onClick={() => removeFile(f.name)}>Remove</button>
+                    </li>
+                  ))}
+                  <li>
+                    <button type="button" className="text-sm text-red-600" onClick={removeAllFiles}>Remove all</button>
+                  </li>
+                </ul>
+              )}
             </div>
             <button type="submit" className="px-4 py-2 bg-indigo-600 text-white rounded">Submit</button>
           </form>
+        )}
+        {screen === 'form' && loadError && (
+          <div className="max-w-md mx-auto p-4 bg-yellow-100 text-yellow-800 rounded" role="alert">
+            {loadError}
+          </div>
         )}
 
         {screen === 'waiting' && (
@@ -255,7 +482,7 @@ const LandingPage: React.FC = () => {
             <div className="max-w-md p-4 border rounded">
               <p>Per Page Rate: ${perPageRate}</p>
               <p>Total Billable Pages: {totalBillablePages}</p>
-              <p>Certification Type: {certType}</p>
+              <p>Certification Type: {displayCertType}</p>
               <p>Certification Price: ${certPrice}</p>
               <p className="font-semibold">Final Total: ${finalTotal.toFixed(2)}</p>
             </div>

--- a/NETLIFY_SETUP.md
+++ b/NETLIFY_SETUP.md
@@ -12,33 +12,37 @@ The backend functions require the environment variables listed below to communic
 
 ## Configuration Steps
 
-1.  **Navigate to your Site:**
-    *   Log in to your Netlify account.
-    *   Go to the "Sites" section and select the site you've deployed from this repository.
+1. **Navigate to your Site:**
+   * Log in to your Netlify account.
+   * Go to the "Sites" section and select the site you've deployed from this repository.
 
-2.  **Go to Site Configuration:**
-    *   From your site's overview page, click on "Site configuration".
+2. **Go to Site Configuration:**
+   * From your site's overview page, click on "Site configuration".
 
-3.  **Find Environment Variables:**
-    *   In the sidebar, navigate to "Environment variables".
+3. **Find Environment Variables:**
+   * In the sidebar, navigate to "Environment variables".
 
-4.  **Add Environment Variables:**
-    *   Click "Add a variable" and select "Create a new variable".
-    *   Add each key-value pair one by one. For sensitive keys, it's highly recommended to use Netlify's "Secret" value type, although standard variables also work.
-    *   Add the following variables with their corresponding values from your service provider dashboards:
+4. **Add Environment Variables:**
+   * Click "Add a variable" and select "Create a new variable".
+   * Add each key-value pair one by one. For sensitive keys, it's highly recommended to use Netlify's "Secret" value type, although standard variables also work.
+   * Add the following variables with their corresponding values from your service provider dashboards:
 
-    | Variable Name                       | Description                                                                                              | Example Value                  |
-    | ----------------------------------- | -------------------------------------------------------------------------------------------------------- | ------------------------------ |
-    | `SUPABASE_URL`                      | The project URL from your Supabase dashboard (Settings > API).                                           | `https://xyz.supabase.co`      |
-    | `SUPABASE_ANON_KEY`                 | The public anonymous key from your Supabase dashboard (Settings > API).                                  | `ey...`                        |
-    | `GEMINI_API_KEY`                    | Your API key from Google AI Studio (used for Gemini and Google Cloud Vision).                                                                      | `AIza...`                      |
-    | `STRIPE_SECRET_KEY`                 | Your Stripe secret key (use a test key for development/staging).                                         | `sk_test_...`                  |
-    | `BREVO_API_KEY`                     | Your API v3 key from the Brevo dashboard (SMTP & API section).                                           | `xkeysib...`                   |
-    | `TEST_EMAIL_RECIPIENT`              | The email address where the Brevo test email will be sent.                                               | `your-email@example.com`       |
-    | `TEST_EMAIL_SENDER`                 | An authenticated sender email address in your Brevo account.                                             | `noreply@yourdomain.com`       |
-5.  **Redeploy:**
-    *   After adding all the variables, you'll need to trigger a new deployment for the changes to take effect.
-    *   Go to the "Deploys" tab for your site.
-    *   Click the "Trigger deploy" dropdown and select "Deploy site".
+   | Variable Name               | Description                                                                 | Example Value             |
+   | --------------------------- | --------------------------------------------------------------------------- | ------------------------ |
+   | `SUPABASE_URL`              | The project URL from your Supabase dashboard (Settings > API).             | `https://xyz.supabase.co` |
+   | `SUPABASE_ANON_KEY`         | The public anonymous key from your Supabase dashboard (Settings > API).    | `ey...`                  |
+   | `VITE_SUPABASE_URL`         | Public URL for the landing page to query Supabase directly.               | `https://xyz.supabase.co` |
+   | `VITE_SUPABASE_ANON_KEY`    | Public anon key for client-side Supabase access.                         | `ey...`                |
+   | `GEMINI_API_KEY`            | Your API key from Google AI Studio (used for Gemini and Google Cloud Vision). | `AIza...`               |
+   | `STRIPE_SECRET_KEY`         | Your Stripe secret key (use a test key for development/staging).           | `sk_test_...`           |
+   | `STRIPE_API_VERSION`        | Optional Stripe API version. Defaults to `2022-11-15` when not set.         | `2022-11-15`            |
+   | `BREVO_API_KEY`             | Your API v3 key from the Brevo dashboard (SMTP & API section).             | `xkeysib...`            |
+   | `TEST_EMAIL_RECIPIENT`      | The email address where the Brevo test email will be sent.                 | `your-email@example.com` |
+   | `TEST_EMAIL_SENDER`         | An authenticated sender email address in your Brevo account.               | `noreply@yourdomain.com` |
+
+5. **Redeploy:**
+   * After adding all the variables, you'll need to trigger a new deployment for the changes to take effect.
+   * Go to the "Deploys" tab for your site.
+   * Click the "Trigger deploy" dropdown and select "Deploy site".
 
 Your backend functions will now have access to these keys via `process.env.VARIABLE_NAME`.

--- a/__env.html
+++ b/__env.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <title>Env Check</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/__env.tsx"></script>
+  </body>
+</html>

--- a/__env.tsx
+++ b/__env.tsx
@@ -1,0 +1,28 @@
+import React from 'react';
+import ReactDOM from 'react-dom/client';
+
+function EnvCheck() {
+  const url = (import.meta as any).env?.VITE_SUPABASE_URL as string | undefined;
+  const key = (import.meta as any).env?.VITE_SUPABASE_ANON_KEY as string | undefined;
+  const mask = (v?: string) => (v ? v.slice(0, 12) + '…' : 'undefined');
+  return (
+    <div style={{ fontFamily: 'sans-serif', padding: 16 }}>
+      <h1>Client Env Check</h1>
+      <p><strong>Has VITE_SUPABASE_URL:</strong> {String(Boolean(url))}</p>
+      <p><strong>VITE_SUPABASE_URL (masked):</strong> {mask(url)}</p>
+      <p><strong>Has VITE_SUPABASE_ANON_KEY:</strong> {String(Boolean(key))}</p>
+      <p><strong>VITE_SUPABASE_ANON_KEY (masked):</strong> {mask(key)}</p>
+    </div>
+  );
+}
+
+const rootElement = document.getElementById('root');
+if (!rootElement) {
+  throw new Error('Could not find root element to mount to');
+}
+
+ReactDOM.createRoot(rootElement).render(
+  <React.StrictMode>
+    <EnvCheck />
+  </React.StrictMode>
+);

--- a/index.html
+++ b/index.html
@@ -6,6 +6,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Certified Translation Quote</title>
     <script src="https://cdn.tailwindcss.com"></script>
+    <!-- TODO: migrate to the Tailwind build pipeline -->
     <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600&family=Montserrat:wght@500&display=swap" rel="stylesheet" />
     <script>
       tailwind.config = {

--- a/lib/supabase-browser.ts
+++ b/lib/supabase-browser.ts
@@ -1,0 +1,30 @@
+import { createClient, SupabaseClient } from '@supabase/supabase-js';
+
+let client: SupabaseClient | null = null;
+
+function createBrowserClient(): SupabaseClient {
+  const url = (import.meta as any).env?.VITE_SUPABASE_URL as string | undefined;
+  const anonKey = (import.meta as any).env?.VITE_SUPABASE_ANON_KEY as string | undefined;
+  console.log('VITE_SUPABASE_URL?', Boolean(url));
+  console.log('VITE_SUPABASE_ANON_KEY?', Boolean(anonKey));
+  if (!url || !anonKey) {
+    throw new Error(
+      'Supabase not configured for this Netlify build context. Ensure VITE_* vars exist for Deploy Preview and clear cache before redeploy.'
+    );
+  }
+  return createClient(url, anonKey);
+}
+
+export function getSupabaseBrowser(): SupabaseClient | null {
+  if (client) return client;
+  try {
+    client = createBrowserClient();
+  } catch (err) {
+    console.warn(err);
+    client = null;
+  }
+  return client;
+}
+
+const supabaseBrowser = getSupabaseBrowser();
+export default supabaseBrowser;

--- a/netlify.toml
+++ b/netlify.toml
@@ -14,3 +14,7 @@
   to = "/.netlify/functions/:splat"
   status = 200
 
+[context.deploy-preview.environment]
+  VITE_SUPABASE_URL = "https://YOUR-PROJECT.supabase.co"
+  VITE_SUPABASE_ANON_KEY = "YOUR-ANON-KEY"
+

--- a/netlify/functions/test-stripe.ts
+++ b/netlify/functions/test-stripe.ts
@@ -11,7 +11,7 @@ export const handler: Handler = async (event) => {
     return methodNotAllowed;
   }
 
-  const { STRIPE_SECRET_KEY } = process.env;
+  const { STRIPE_SECRET_KEY, STRIPE_API_VERSION } = process.env;
 
   if (!STRIPE_SECRET_KEY) {
     return {
@@ -24,9 +24,11 @@ export const handler: Handler = async (event) => {
   }
   
   try {
+    const apiVersion =
+      (STRIPE_API_VERSION as Stripe.LatestApiVersion | undefined) || '2022-11-15';
+
     const stripe = new Stripe(STRIPE_SECRET_KEY, {
-      // Fix: Update Stripe API version to match the required type from the SDK.
-      apiVersion: '2025-08-27.basil', 
+      apiVersion,
     });
 
     // A safe, read-only operation to test the API key

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -10,6 +10,7 @@ export default defineConfig({
       input: {
         main: resolve(__dirname, 'index.html'),
         diagnostics: resolve(__dirname, 'diagnostics.html'),
+        __env: resolve(__dirname, '__env.html'),
       },
     },
   },


### PR DESCRIPTION
## Summary
- default Stripe API version to supported `2022-11-15`
- document `STRIPE_API_VERSION` default in Netlify setup guide
- add browser Supabase helper using `VITE_SUPABASE_URL`/`VITE_SUPABASE_ANON_KEY` with console guard
- guard mobile menu MutationObserver and show setup message when Supabase envs are missing
- document new public Supabase variables and note Tailwind CDN TODO
- load quote form dropdowns from Supabase tables and disable selects while fetching
- improve file upload UX with inline file list and removal controls
- expose `/__env` page to verify Vite vars and map Deploy Preview envs in `netlify.toml`
- add fetch diagnostics and Supabase connectivity ping for Deploy Preview debugging

## Testing
- `npm test` *(fails: command not found)*
- `npm run build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c5abf8d5c083308276a0daa119414c