### PR TITLE
Add review screen and email quote flow

### DIFF
--- a/LandingPage.tsx
+++ b/LandingPage.tsx
@@ -1,15 +1,11 @@
-import React, { useState, useEffect } from 'react';
+import React, { useState, useEffect, useRef } from 'react';
 import Spinner from './components/Spinner';
 import Logo from './components/Logo';
-import { createClient } from '@supabase/supabase-js';
 import { runOcr, OcrResult } from './integrations/googleVision';
 import { analyzeWithGemini, GeminiAnalysis } from './integrations/gemini';
+import supabase from './src/lib/supabaseClient';
 
-const supabaseUrl = (import.meta as any).env.VITE_SUPABASE_URL as string;
-const supabaseAnonKey = (import.meta as any).env.VITE_SUPABASE_ANON_KEY as string;
-const supabase = createClient(supabaseUrl, supabaseAnonKey);
-
-type Screen = 'form' | 'waiting' | 'result' | 'error';
+type Screen = 'form' | 'waiting' | 'review' | 'result' | 'error';
 
 interface CombinedPage {
   pageNumber: number;
@@ -25,6 +21,10 @@ interface CombinedFile {
 
 const allowedExtensions = ['jpg','jpeg','png','tiff','doc','docx','pdf','xls','xlsx'];
 
+function uniqSorted(arr: (string | null | undefined)[] = []) {
+  return Array.from(new Set(arr.filter(Boolean) as string[])).sort((a, b) => a.localeCompare(b));
+}
+
 const LandingPage: React.FC = () => {
   const [customerName, setCustomerName] = useState('');
   const [customerEmail, setCustomerEmail] = useState('');
@@ -32,10 +32,19 @@ const LandingPage: React.FC = () => {
   const [intendedUse, setIntendedUse] = useState('');
   const [sourceLanguage, setSourceLanguage] = useState('');
   const [targetLanguage, setTargetLanguage] = useState('');
-  const [files, setFiles] = useState<FileList | null>(null);
+  const [files, setFiles] = useState<File[]>([]);
+  const fileInputRef = useRef<HTMLInputElement | null>(null);
 
-  const [intendedUseOptions, setIntendedUseOptions] = useState<string[]>([]);
-  const [languageOptions, setLanguageOptions] = useState<string[]>([]);
+  const [languages, setLanguages] = useState<string[]>([]);
+  const [intendedUses, setIntendedUses] = useState<string[]>([]);
+  const [loadingDropdowns, setLoadingDropdowns] = useState(false);
+  const [dropdownError, setDropdownError] = useState<string | null>(null);
+  // DO NOT EDIT OUTSIDE THIS BLOCK
+  const [certTypes, setCertTypes] = useState<any[]>([]);
+  const [tiers, setTiers] = useState<any[]>([]);
+  const [languagesData, setLanguagesData] = useState<any[]>([]);
+  const [certificationMap, setCertificationMap] = useState<any[]>([]);
+  // DO NOT EDIT OUTSIDE THIS BLOCK
 
   const [errors, setErrors] = useState<Record<string,string>>({});
   const [screen, setScreen] = useState<Screen>('form');
@@ -43,16 +52,58 @@ const LandingPage: React.FC = () => {
   const [results, setResults] = useState<CombinedFile[]>([]);
   const [errorStep, setErrorStep] = useState('');
   const [menuOpen, setMenuOpen] = useState(false);
+  const [quoteId, setQuoteId] = useState<string | null>(null);
 
   useEffect(() => {
-    async function fetchOptions() {
-      const { data: uses } = await supabase.from('CertificationMap').select('intendedUse');
-      const uniqueUses = Array.from(new Set((uses ?? []).map((u: any) => u.intendedUse).filter(Boolean)));
-      setIntendedUseOptions(uniqueUses);
-      const { data: langs } = await supabase.from('Languages').select('name');
-      setLanguageOptions((langs ?? []).map((l: any) => l.name));
-    }
-    fetchOptions();
+    let mounted = true;
+    (async () => {
+      try {
+        setLoadingDropdowns(true);
+        setDropdownError(null);
+
+        // DO NOT EDIT OUTSIDE THIS BLOCK
+        const { data: langRows, error: langErr } = await supabase
+          .from('languages')
+          .select('languagename, tier')
+          .order('languagename', { ascending: true });
+        if (langErr) throw langErr;
+
+        const { data: tierRows, error: tierErr } = await supabase
+          .from('tiers')
+          .select('tier, multiplier')
+          .order('tier', { ascending: true });
+        if (tierErr) throw tierErr;
+
+        const { data: ctypeRows, error: ctypeErr } = await supabase
+          .from('certificationtypes')
+          .select('certtype, price')
+          .order('certtype', { ascending: true });
+        if (ctypeErr) throw ctypeErr;
+
+        const { data: cmapRows, error: cmapErr } = await supabase
+          .from('certificationmap')
+          .select('intendeduse, certtype')
+          .order('intendeduse', { ascending: true });
+        if (cmapErr) throw cmapErr;
+
+        if (!mounted) return;
+        setLanguagesData((langRows ?? []).map(r => ({ name: r.languagename, tier: r.tier })));
+        setLanguages(uniqSorted((langRows ?? []).map(r => r.languagename)));
+        setTiers(tierRows ?? []);
+        setCertTypes((ctypeRows ?? []).map(r => ({ certType: r.certtype, price: r.price })));
+        setCertificationMap((cmapRows ?? []).map(r => ({ intendedUse: r.intendeduse, certType: r.certtype })));
+        setIntendedUses(uniqSorted((cmapRows ?? []).map(r => r.intendeduse)));
+        // DO NOT EDIT OUTSIDE THIS BLOCK
+      } catch (e: any) {
+        if (mounted) setDropdownError('Could not load form options. Please retry.');
+        console.error('Dropdown fetch failed:', e?.message || e);
+      } finally {
+        if (mounted) setLoadingDropdowns(false);
+      }
+    })();
+    return () => {
+      mounted = false;
+    };
   }, []);
 
   const validate = (): boolean => {
@@ -62,15 +113,13 @@ const LandingPage: React.FC = () => {
     if(!intendedUse) newErrors.intendedUse = 'Intended use required';
     if(!sourceLanguage) newErrors.sourceLanguage = 'Source language required';
     if(!targetLanguage) newErrors.targetLanguage = 'Target language required';
-    if(!files || files.length === 0) newErrors.files = 'At least one file required';
-    if(files){
-      Array.from(files).forEach(f => {
-        const ext = f.name.split('.').pop()?.toLowerCase();
-        if(!ext || !allowedExtensions.includes(ext)){
-          newErrors.files = 'Unsupported file type';
-        }
-      });
-    }
+    if(files.length === 0) newErrors.files = 'At least one file required';
+    files.forEach(f => {
+      const ext = f.name.split('.').pop()?.toLowerCase();
+      if(!ext || !allowedExtensions.includes(ext)){
+        newErrors.files = 'Unsupported file type';
+      }
+    });
     setErrors(newErrors);
     return Object.keys(newErrors).length === 0;
   };
@@ -78,16 +127,28 @@ const LandingPage: React.FC = () => {
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
     if(!validate()) return;
-    if(!files) return;
+    if(files.length === 0) return;
     try{
       setScreen('waiting');
-      setStatusText('Uploading…');
-      // Mock upload delay
-      await new Promise(r => setTimeout(r, 300));
+      setStatusText('Saving quote…');
+      // DO NOT EDIT OUTSIDE THIS BLOCK
+      const formData = new FormData();
+      formData.append('name', customerName);
+      formData.append('email', customerEmail);
+      formData.append('phone', customerPhone);
+      formData.append('intendedUse', intendedUse);
+      formData.append('sourceLanguage', sourceLanguage);
+      formData.append('targetLanguage', targetLanguage);
+      files.forEach(f => formData.append('files[]', f));
+      const saveRes = await fetch('/api/save-quote', { method: 'POST', body: formData });
+      if(!saveRes.ok) throw new Error('Save failed');
+      const saveJson = await saveRes.json();
+      setQuoteId(saveJson.quote_id);
+      // DO NOT EDIT OUTSIDE THIS BLOCK
 
       setStatusText('Analyzing with OCR…');
       const ocrResults: OcrResult[] = [];
-      for (const file of Array.from(files)) {
+      for (const file of files) {
         const ocr = await runOcr(file.name, file.name);
         ocrResults.push(ocr);
       }
@@ -112,7 +173,7 @@ const LandingPage: React.FC = () => {
         }))
       }));
       setResults(combined);
-      setScreen('result');
+      setScreen('review');
     } catch(err){
       const current = statusText.includes('OCR') ? 'OCR' : statusText.includes('Gemini') ? 'Gemini' : 'Upload';
       setErrorStep(current);
@@ -120,13 +181,56 @@ const LandingPage: React.FC = () => {
     }
   };
 
-  const totalBillablePages = results.reduce((sum, file) => {
-    return sum + file.pages.reduce((s,p)=> s + Math.ceil(p.wordCount/250),0);
-  },0);
-  const perPageRate = 20;
-  const certType = intendedUse || 'Standard';
-  const certPrice = 50;
-  const finalTotal = perPageRate * totalBillablePages + certPrice;
+  // DO NOT EDIT OUTSIDE THIS BLOCK
+  const fileSummaries = results.map(file => ({
+    fileName: file.fileName,
+    pages: file.pages.reduce((s,p)=> s + Math.ceil(p.wordCount/250),0)
+  }));
+  const billablePagesTotal = fileSummaries.reduce((s,f)=> s + f.pages, 0);
+  const selectedCertTypeName = certificationMap.find((m:any)=>m.intendedUse===intendedUse)?.certType;
+  const selectedCertType = certTypes.find((c:any)=>c.certType===selectedCertTypeName);
+  const sourceTierName = languagesData.find((l:any)=>l.name===sourceLanguage)?.tier;
+  const targetTierName = languagesData.find((l:any)=>l.name===targetLanguage)?.tier;
+  const sourceTier = tiers.find((t:any)=>t.tier===sourceTierName);
+  const targetTier = tiers.find((t:any)=>t.tier===targetTierName);
+  const selectedTier = sourceTier && targetTier ? (sourceTier.multiplier > targetTier.multiplier ? sourceTier : targetTier) : (sourceTier || targetTier);
+  const base = selectedCertType?.price ?? 0;
+  const mult = selectedTier?.multiplier ?? 1;
+  const rate = +(base * mult).toFixed(2);
+  const total = +(rate * billablePagesTotal).toFixed(2);
+  // DO NOT EDIT OUTSIDE THIS BLOCK
+
+  // DO NOT EDIT OUTSIDE THIS BLOCK
+  const sendEmail = async () => {
+    try {
+      const res = await fetch('/api/send-quote', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          name: customerName,
+          email: customerEmail,
+          phone: customerPhone,
+          intendedUse,
+          sourceLanguage,
+          targetLanguage,
+          rate,
+          billablePages: billablePagesTotal,
+          total,
+          files: fileSummaries.map(f => ({ name: f.fileName, pages: f.pages }))
+        })
+      });
+      if (res.ok) {
+        setScreen('result');
+      } else {
+        setErrorStep('Email');
+        setScreen('error');
+      }
+    } catch {
+      setErrorStep('Email');
+      setScreen('error');
+    }
+  };
+  // DO NOT EDIT OUTSIDE THIS BLOCK
 
   return (
     <div className="min-h-screen flex flex-col">
@@ -159,6 +263,11 @@ const LandingPage: React.FC = () => {
                 Please correct the highlighted fields.
               </div>
             )}
+            {dropdownError && (
+              <div className="bg-red-100 text-red-700 p-2 rounded" role="alert">
+                {dropdownError}
+              </div>
+            )}
             <div>
               <label className="block font-medium" htmlFor="customerName">Name*</label>
               <input id="customerName" type="text" value={customerName} onChange={e=>setCustomerName(e.target.value)} aria-invalid={errors.customerName ? 'true' : undefined} className="w-full border p-2 rounded" />
@@ -175,7 +284,7 @@ const LandingPage: React.FC = () => {
               <label className="block font-medium" htmlFor="intendedUse">Intended Use*</label>
               <select id="intendedUse" value={intendedUse} onChange={e=>setIntendedUse(e.target.value)} aria-invalid={errors.intendedUse ? 'true' : undefined} className="w-full border p-2 rounded">
                 <option value="">Select...</option>
-                {intendedUseOptions.map(opt => <option key={opt} value={opt}>{opt}</option>)}
+                {intendedUses.map(opt => <option key={opt} value={opt}>{opt}</option>)}
               </select>
             </div>
             <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
@@ -183,20 +292,66 @@ const LandingPage: React.FC = () => {
                 <label className="block font-medium" htmlFor="sourceLanguage">Source Language*</label>
                 <select id="sourceLanguage" value={sourceLanguage} onChange={e=>setSourceLanguage(e.target.value)} aria-invalid={errors.sourceLanguage ? 'true' : undefined} className="w-full border p-2 rounded">
                   <option value="">Select...</option>
-                  {languageOptions.map(l => <option key={l} value={l}>{l}</option>)}
+                  {languages.map(l => <option key={l} value={l}>{l}</option>)}
                 </select>
               </div>
               <div>
                 <label className="block font-medium" htmlFor="targetLanguage">Target Language*</label>
                 <select id="targetLanguage" value={targetLanguage} onChange={e=>setTargetLanguage(e.target.value)} aria-invalid={errors.targetLanguage ? 'true' : undefined} className="w-full border p-2 rounded">
                   <option value="">Select...</option>
-                  {languageOptions.map(l => <option key={l} value={l}>{l}</option>)}
+                  {languages.map(l => <option key={l} value={l}>{l}</option>)}
                 </select>
               </div>
             </div>
             <div>
               <label className="block font-medium" htmlFor="files">Upload Files*</label>
-              <input id="files" type="file" multiple accept=".jpg,.jpeg,.png,.tiff,.doc,.docx,.pdf,.xls,.xlsx" onChange={e=>setFiles(e.target.files)} aria-invalid={errors.files ? 'true' : undefined} className="w-full border p-2 rounded" />
+              <input
+                ref={fileInputRef}
+                id="files"
+                type="file"
+                multiple
+                accept=".jpg,.jpeg,.png,.tiff,.doc,.docx,.pdf,.xls,.xlsx"
+                onChange={(e) => {
+                  const selected = Array.from(e.target.files || []);
+                  const byKey = new Map(files.map(f => [f.name + ':' + f.size, f]));
+                  for (const f of selected) byKey.set(f.name + ':' + f.size, f);
+                  setFiles(Array.from(byKey.values()));
+                }}
+                aria-invalid={errors.files ? 'true' : undefined}
+                className="w-full border p-2 rounded mt-1"
+              />
+              {files.length > 0 && (
+                <div className="mt-2 space-y-2">
+                  {files.map((f, idx) => (
+                    <div key={f.name + ':' + f.size} className="flex items-center justify-between rounded border p-2">
+                      <span className="text-sm truncate">{f.name}</span>
+                      <button
+                        type="button"
+                        className="text-xs underline"
+                        onClick={() => {
+                          const next = files.filter((_, i) => i !== idx);
+                          setFiles(next);
+                          if (next.length === 0 && fileInputRef.current) {
+                            fileInputRef.current.value = '';
+                          }
+                        }}
+                      >
+                        Remove
+                      </button>
+                    </div>
+                  ))}
+                  <button
+                    type="button"
+                    className="text-xs underline mt-1"
+                    onClick={() => {
+                      setFiles([]);
+                      if (fileInputRef.current) fileInputRef.current.value = '';
+                    }}
+                  >
+                    Remove all
+                  </button>
+                </div>
+              )}
             </div>
             <button type="submit" className="px-4 py-2 bg-indigo-600 text-white rounded">Submit</button>
           </form>
@@ -216,49 +371,45 @@ const LandingPage: React.FC = () => {
           </div>
         )}
 
-        {screen === 'result' && (
+        {screen === 'review' && (
           <div className="space-y-6">
             <table className="min-w-full text-sm border">
               <thead>
                 <tr className="bg-gray-200 dark:bg-gray-700">
-                  <th className="p-2 border">File</th>
-                  <th className="p-2 border">Page</th>
-                  <th className="p-2 border">Wordcount</th>
-                  <th className="p-2 border">Complexity</th>
-                  <th className="p-2 border">Multiplier</th>
-                  <th className="p-2 border">PPWC</th>
-                  <th className="p-2 border">Billable Pages</th>
+                  <th className="p-2 border">Filename</th>
+                  <th className="p-2 border">Billable Pages (total)</th>
+                  <th className="p-2 border">Rate</th>
+                  <th className="p-2 border">Total</th>
                 </tr>
               </thead>
               <tbody>
-                {results.map(file => (
-                  <React.Fragment key={file.fileName}>
-                    {file.pages.map((p, idx) => {
-                      const ppwc = (p.wordCount * p.complexityMultiplier).toFixed(2);
-                      const billable = Math.ceil(p.wordCount/250);
-                      return (
-                        <tr key={idx} className="border-t">
-                          <td className="p-2 border">{idx===0 ? file.fileName : ''}</td>
-                          <td className="p-2 border">{p.pageNumber}</td>
-                          <td className="p-2 border">{p.wordCount}</td>
-                          <td className="p-2 border">{p.complexity}</td>
-                          <td className="p-2 border">{p.complexityMultiplier}</td>
-                          <td className="p-2 border">{ppwc}</td>
-                          <td className="p-2 border">{billable}</td>
-                        </tr>
-                      );
-                    })}
-                  </React.Fragment>
+                {fileSummaries.map(f => (
+                  <tr key={f.fileName} className="border-t">
+                    <td className="p-2 border">{f.fileName}</td>
+                    <td className="p-2 border">{f.pages}</td>
+                    <td className="p-2 border">${rate.toFixed(2)}</td>
+                    <td className="p-2 border">${(f.pages * rate).toFixed(2)}</td>
+                  </tr>
                 ))}
               </tbody>
+              <tfoot>
+                <tr className="font-semibold">
+                  <td className="p-2 border">Total Billable Pages</td>
+                  <td className="p-2 border">{billablePagesTotal}</td>
+                  <td className="p-2 border"></td>
+                  <td className="p-2 border">${total.toFixed(2)}</td>
+                </tr>
+              </tfoot>
             </table>
-            <div className="max-w-md p-4 border rounded">
-              <p>Per Page Rate: ${perPageRate}</p>
-              <p>Total Billable Pages: {totalBillablePages}</p>
-              <p>Certification Type: {certType}</p>
-              <p>Certification Price: ${certPrice}</p>
-              <p className="font-semibold">Final Total: ${finalTotal.toFixed(2)}</p>
+            <div className="flex space-x-2">
+              <button className="px-4 py-2 bg-gray-300 rounded" onClick={()=>setScreen('form')}>Back</button>
+              <button className="px-4 py-2 bg-indigo-600 text-white rounded" onClick={sendEmail}>Email your quote</button>
             </div>
+          </div>
+        )}
+        {screen === 'result' && (
+          <div className="max-w-md mx-auto text-center space-y-4">
+            <p className="text-green-700">Quote emailed successfully.</p>
             <button className="px-4 py-2 bg-indigo-600 text-white rounded" onClick={()=>setScreen('form')}>New Quote</button>
           </div>
         )}

--- a/api/save-quote.ts
+++ b/api/save-quote.ts
@@ -1,0 +1,80 @@
+// DO NOT EDIT OUTSIDE THIS BLOCK
+import { createClient } from '@supabase/supabase-js';
+import formidable from 'formidable';
+import fs from 'fs/promises';
+import type { IncomingMessage, ServerResponse } from 'http';
+
+interface ApiResponse extends ServerResponse {
+  status(code: number): this;
+  json(data: any): this;
+}
+
+export default async function handler(req: IncomingMessage, res: ApiResponse) {
+  if (req.method !== 'POST') {
+    return res.status(405).json({ error: 'Method Not Allowed' });
+  }
+
+  const url = process.env.VITE_SUPABASE_URL;
+  const key = process.env.VITE_SUPABASE_ANON_KEY;
+  if (!url || !key) {
+    return res.status(500).json({ error: 'Missing Supabase configuration' });
+  }
+  const supabase = createClient(url, key);
+
+  const form = formidable({ multiples: true });
+  const { fields, files } = await new Promise<{ fields: any; files: any }>((resolve, reject) => {
+    form.parse(req, (err, fields, files) => {
+      if (err) reject(err);
+      else resolve({ fields, files });
+    });
+  });
+
+  const name = fields.name?.[0] || fields.name || '';
+  const email = fields.email?.[0] || fields.email || '';
+  const phone = fields.phone?.[0] || fields.phone || '';
+  const intendedUse = fields.intendedUse?.[0] || fields.intendedUse || '';
+  const sourceLanguage = fields.sourceLanguage?.[0] || fields.sourceLanguage || '';
+  const targetLanguage = fields.targetLanguage?.[0] || fields.targetLanguage || '';
+
+  const { data: submission, error: insertErr } = await supabase
+    .from('quote_submissions')
+    .insert({
+      name,
+      email,
+      phone,
+      intended_use: intendedUse,
+      source_language: sourceLanguage,
+      target_language: targetLanguage,
+    })
+    .select('quote_id')
+    .single();
+  if (insertErr || !submission) {
+    return res.status(500).json({ error: 'Database insert failed' });
+  }
+  const quoteId = submission.quote_id as string;
+
+  const fileInput = files['files[]'];
+  const fileArray = Array.isArray(fileInput) ? fileInput : [fileInput].filter(Boolean);
+  const uploaded: { file_name: string; storage_path: string; url: string | null }[] = [];
+  for (const f of fileArray) {
+    const fileBuffer = await fs.readFile(f.filepath);
+    const fileName = f.originalFilename as string;
+    const storagePath = `orders/${quoteId}/${fileName}`;
+    const { error: uploadErr } = await supabase.storage.from('orders').upload(storagePath, fileBuffer);
+    if (uploadErr) {
+      return res.status(500).json({ error: 'Storage upload failed' });
+    }
+    const { data: pub } = supabase.storage.from('orders').getPublicUrl(storagePath);
+    const url = pub?.publicUrl || null;
+    await supabase.from('quote_files').insert({
+      quote_id: quoteId,
+      file_name: fileName,
+      storage_path: storagePath,
+      public_url: url,
+    });
+    uploaded.push({ file_name: fileName, storage_path: storagePath, url });
+  }
+
+  return res.status(200).json({ quote_id: quoteId, files: uploaded });
+}
+// DO NOT EDIT OUTSIDE THIS BLOCK

--- a/api/send-quote.ts
+++ b/api/send-quote.ts
@@ -1,0 +1,57 @@
+// DO NOT EDIT OUTSIDE THIS BLOCK
+import * as SibApiV3Sdk from '@getbrevo/brevo';
+import type { IncomingMessage, ServerResponse } from 'http';
+
+interface ApiResponse extends ServerResponse {
+  status(code: number): this;
+  json(data: any): this;
+}
+
+export default async function handler(req: IncomingMessage, res: ApiResponse) {
+  if (req.method !== 'POST') {
+    return res.status(405).json({ success: false, error: 'Method Not Allowed' });
+  }
+
+  const apiKey = process.env.BREVO_API_KEY;
+  const senderEmail = process.env.TEST_EMAIL_SENDER;
+  if (!apiKey || !senderEmail) {
+    return res.status(500).json({ success: false, error: 'Missing Brevo configuration' });
+  }
+
+  let body = '';
+  req.on('data', chunk => { body += chunk; });
+  await new Promise(resolve => req.on('end', resolve));
+
+  let payload: any = {};
+  try {
+    payload = JSON.parse(body || '{}');
+  } catch {
+    return res.status(400).json({ success: false, error: 'Invalid JSON' });
+  }
+
+  const { name, email, phone, intendedUse, sourceLanguage, targetLanguage, rate, billablePages, total, files } = payload;
+
+  try {
+    const apiInstance = new SibApiV3Sdk.TransactionalEmailsApi();
+    apiInstance.setApiKey(SibApiV3Sdk.TransactionalEmailsApiApiKeys.apiKey, apiKey);
+
+    const rows = Array.isArray(files)
+      ? files.map((f: any) => `<tr><td>${f.name}</td><td>${f.pages}</td><td>$${rate}</td><td>$${(f.pages * rate).toFixed(2)}</td></tr>`).join('')
+      : '';
+
+    const html = `<html><body><h1>Quote Review</h1><p>Name: ${name}<br/>Phone: ${phone}<br/>Intended Use: ${intendedUse}<br/>Source: ${sourceLanguage} -> Target: ${targetLanguage}</p><table border="1" cellpadding="5" cellspacing="0"><thead><tr><th>Filename</th><th>Billable Pages (total)</th><th>Rate</th><th>Total</th></tr></thead><tbody>${rows}</tbody><tfoot><tr><td>Total Billable Pages</td><td>${billablePages}</td><td></td><td>$${total}</td></tr></tfoot></table></body></html>`;
+
+    const sendSmtpEmail = new SibApiV3Sdk.SendSmtpEmail();
+    sendSmtpEmail.subject = 'Your Translation Quote';
+    sendSmtpEmail.htmlContent = html;
+    sendSmtpEmail.sender = { name: 'Quote Bot', email: senderEmail };
+    sendSmtpEmail.to = [{ email, name }];
+
+    await apiInstance.sendTransacEmail(sendSmtpEmail);
+    return res.status(200).json({ success: true });
+  } catch (error: any) {
+    return res.status(500).json({ success: false, error: `Brevo API error: ${error.message}` });
+  }
+}
+// DO NOT EDIT OUTSIDE THIS BLOCK
+

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "@google-cloud/vision": "^4.3.0",
     "@google/genai": "^0.14.0",
     "@supabase/supabase-js": "^2.44.2",
+    "formidable": "^2.1.5",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "stripe": "^16.1.0"

--- a/src/lib/supabaseClient.ts
+++ b/src/lib/supabaseClient.ts
@@ -1,0 +1,14 @@
+import { createClient } from '@supabase/supabase-js';
+
+const url = (import.meta as any).env.VITE_SUPABASE_URL as string | undefined;
+const anonKey = (import.meta as any).env.VITE_SUPABASE_ANON_KEY as string | undefined;
+
+if (!url || url.includes('YOUR_SUPABASE_URL')) {
+  throw new Error('VITE_SUPABASE_URL is not set');
+}
+if (!anonKey || anonKey.includes('YOUR_SUPABASE_ANON_KEY')) {
+  throw new Error('VITE_SUPABASE_ANON_KEY is not set');
+}
+
+const supabase = createClient(url, anonKey);
+export default supabase;

--- a/user_actions.md
+++ b/user_actions.md
@@ -1,0 +1,44 @@
+# User Actions
+
+## Database Setup
+```sql
+create table if not exists public.quote_submissions (
+  quote_id uuid primary key default gen_random_uuid(),
+  name text not null,
+  email text not null,
+  phone text not null,
+  intended_use text not null,
+  source_language text not null,
+  target_language text not null,
+  created_at timestamptz default now()
+);
+
+create table if not exists public.quote_files (
+  id uuid primary key default gen_random_uuid(),
+  quote_id uuid not null references public.quote_submissions(quote_id) on delete cascade,
+  file_name text not null,
+  storage_path text not null,
+  public_url text,
+  created_at timestamptz default now()
+);
+
+create index if not exists quote_files_quote_id_idx on public.quote_files(quote_id);
+```
+
+## Bucket Policy
+- Use the existing `orders` storage bucket.
+- Upload files to `orders/{quote_id}/{filename}`.
+- If the bucket is private, store only `storage_path` and generate signed URLs when needed.
+- If the bucket is public, the API stores `public_url` for each file.
+
+## Environment Variables
+- `VITE_SUPABASE_URL`
+- `VITE_SUPABASE_ANON_KEY`
+
+## Sanity Checks
+1. Submit the quote form and verify a row appears in `quote_submissions` with a new `quote_id`.
+2. Confirm each uploaded file exists in `orders/{quote_id}/` in Supabase storage.
+3. Check `quote_files` for entries referencing the `quote_id` and file paths.
+4. Ensure the frontend receives and stores the returned `quote_id`.
+5. Hidden fields (`certification type`, `tier`) remain absent from the UI.
+6. No email is sent during this flow.


### PR DESCRIPTION
## Summary
- Hide backend-only certification and tier inputs
- Add review screen with per-file summaries and email quote option
- Persist quote submissions and files to Supabase storage via `/api/save-quote`

## Testing
- `npm test` *(fails: Missing script)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68c60c0f455c8330b46f5a1e4b4a3a78