### PR TITLE
feat(ocr+gemini): wire GOOGLE_API_KEY & robust errors; keep overlay until Gemini completes; extend OCR URL TTL

### DIFF
--- a/netlify/functions/run-gemini-analyze.ts
+++ b/netlify/functions/run-gemini-analyze.ts
@@ -1,0 +1,162 @@
+import type { Handler } from "@netlify/functions";
+import { GoogleGenerativeAI } from "@google/generative-ai";
+import { Storage } from "@google-cloud/storage";
+import { createClient } from "@supabase/supabase-js";
+import { getStorage } from "./_shared/gcpCreds";
+
+const MODEL = process.env.GEMINI_MODEL || "gemini-1.5-flash";
+console.log("[gemini] model:", MODEL);
+
+function json(statusCode: number, body: Record<string, unknown>) {
+  return { statusCode, body: JSON.stringify(body) };
+}
+
+async function loadOcrText(bucket: string, prefix: string, cap = 50000) {
+  const storage = await getStorage(Storage);
+  const [files] = await storage.bucket(bucket).getFiles({ prefix });
+  const jsonFiles = files
+    .filter((file) => file.name.endsWith(".json"))
+    .sort((a, b) => a.name.localeCompare(b.name));
+
+  let combined = "";
+  for (const file of jsonFiles) {
+    if (combined.length >= cap) break;
+    const [buffer] = await file.download();
+    const payload = JSON.parse(buffer.toString("utf8"));
+    for (const response of payload.responses || []) {
+      const text = response?.fullTextAnnotation?.text || "";
+      if (!text) continue;
+      const remaining = Math.max(0, cap - combined.length);
+      combined += text.slice(0, remaining);
+      if (text.length > remaining) {
+        combined += "\n[TRUNCATED]\n";
+      }
+      if (combined.length >= cap) break;
+    }
+  }
+  return combined.trim();
+}
+
+function extractJson(text: string) {
+  const fenced = text.match(/```json\s*([\s\S]*?)```/i)?.[1];
+  const body = fenced || text;
+  const obj = body.match(/\{[\s\S]*\}/);
+  return obj ? obj[0] : body;
+}
+
+export const handler: Handler = async (event) => {
+  try {
+    if (event.httpMethod !== "GET") {
+      return json(405, { status: "error", message: "Method GET required" });
+    }
+
+    const API_KEY = process.env.GOOGLE_API_KEY;
+    if (!API_KEY) {
+      return json(500, { status: "error", message: "GOOGLE_API_KEY missing" });
+    }
+
+    const outputBucket = process.env.GCS_OUTPUT_BUCKET;
+    if (!outputBucket) {
+      return json(500, { status: "error", message: "GCS_OUTPUT_BUCKET missing" });
+    }
+
+    const supabaseUrl = process.env.SUPABASE_URL;
+    const supabaseServiceKey = process.env.SUPABASE_SERVICE_ROLE_KEY;
+    if (!supabaseUrl || !supabaseServiceKey) {
+      return json(500, { status: "error", message: "Supabase configuration missing" });
+    }
+
+    const quote_id = (event.queryStringParameters?.quote_id || "").trim();
+    const file_name = (event.queryStringParameters?.file_name || "").trim();
+    if (!quote_id || !file_name) {
+      return json(400, { status: "error", message: "quote_id and file_name required" });
+    }
+
+    const prefix = `vision/${quote_id}/${file_name}/`;
+    const text = await loadOcrText(outputBucket, prefix);
+    if (!text) {
+      return json(404, { status: "error", message: "No OCR text found" });
+    }
+
+    const genAI = new GoogleGenerativeAI(API_KEY);
+    const model = genAI.getGenerativeModel({ model: MODEL });
+
+    const DOC_TYPES = [
+      "passport",
+      "birth_certificate",
+      "marriage_certificate",
+      "divorce_certificate",
+      "driver_license",
+      "id_card",
+      "pr_card",
+      "work_permit",
+      "study_permit",
+      "diploma",
+      "transcript",
+      "police_certificate",
+      "bank_statement",
+      "payslip",
+      "utility_bill",
+      "tax_return",
+      "letter",
+      "invoice",
+      "other",
+    ];
+
+    const prompt = `Return STRICT JSON only (no prose).
+Shape:
+{
+  "doc_type": one of ${JSON.stringify(DOC_TYPES)},
+  "primary_language": string,             // language/locale code
+  "secondary_languages": string[],
+  "names": string[],                      // max 5
+  "confidence": number                    // 0..1
+}
+Document text:
+-----
+${text}
+-----`;
+
+    const result = await model.generateContent(prompt);
+    const raw = result.response.text().trim();
+
+    let parsed: any;
+    try {
+      parsed = JSON.parse(extractJson(raw));
+    } catch {
+      return json(502, { status: "error", message: `Bad JSON from model: ${raw}` });
+    }
+
+    const supabase = createClient(supabaseUrl, supabaseServiceKey);
+    const update = {
+      gem_doc_type: DOC_TYPES.includes(parsed.doc_type) ? parsed.doc_type : "other",
+      gem_language_code: parsed.primary_language || null,
+      gem_names: parsed.names || null,
+      gem_status: "success",
+      gem_message: `Gemini classification complete (${MODEL})`,
+      gem_model: MODEL,
+      gem_completed_at: new Date().toISOString(),
+    };
+
+    const { error } = await supabase
+      .from("quote_files")
+      .update(update)
+      .eq("quote_id", quote_id)
+      .eq("file_name", file_name);
+
+    if (error) {
+      return json(500, { status: "error", message: `DB error: ${error.message}` });
+    }
+
+    return json(200, {
+      status: "ok",
+      message: `Gemini classification complete (${MODEL})`,
+      update,
+    });
+  } catch (err: any) {
+    console.error("[gemini] run-gemini-analyze error:", err);
+    return json(500, { status: "error", message: err?.message || String(err) });
+  }
+};
+
+export default handler;

--- a/netlify/functions/run-vision-ocr.ts
+++ b/netlify/functions/run-vision-ocr.ts
@@ -1,0 +1,272 @@
+import type { Handler } from "@netlify/functions";
+import { createClient } from "@supabase/supabase-js";
+import vision from "@google-cloud/vision";
+import pdfParse from "pdf-parse";
+import crypto from "crypto";
+import type { OcrResult } from "../../types";
+
+const SUPABASE_URL =
+  process.env.SUPABASE_URL ||
+  process.env.SUPABASE_PROJECT_URL ||
+  "";
+const SUPABASE_SERVICE_ROLE =
+  process.env.SUPABASE_SERVICE_ROLE_KEY ||
+  process.env.SUPABASE_SERVICE_ROLE ||
+  "";
+
+const credsJson = process.env.GOOGLE_APPLICATION_CREDENTIALS_JSON;
+let visionClient: vision.ImageAnnotatorClient;
+try {
+  visionClient = credsJson
+    ? new vision.ImageAnnotatorClient({ credentials: JSON.parse(credsJson) })
+    : new vision.ImageAnnotatorClient();
+} catch (err) {
+  console.error("[vision] Failed to initialize ImageAnnotatorClient:", err);
+  visionClient = new vision.ImageAnnotatorClient();
+}
+
+function json(statusCode: number, body: Record<string, unknown>) {
+  return { statusCode, body: JSON.stringify(body) };
+}
+
+function countWords(text: string) {
+  return (text.match(/\b\w+\b/gu) || []).length;
+}
+
+export const handler: Handler = async (event) => {
+  try {
+    if (event.httpMethod !== "POST") {
+      return json(405, { status: "error", message: "Method POST required" });
+    }
+
+    if (!SUPABASE_URL || !SUPABASE_SERVICE_ROLE) {
+      return json(500, {
+        status: "error",
+        message: "Server configuration missing Supabase credentials.",
+      });
+    }
+
+    let payload: any;
+    try {
+      payload = JSON.parse(event.body || "{}");
+    } catch {
+      return json(400, { status: "error", message: "Invalid JSON body" });
+    }
+
+    const { quote_id, files } = payload || {};
+    if (!quote_id || !Array.isArray(files) || files.length === 0) {
+      return json(400, {
+        status: "error",
+        message: "Missing quote_id or files array",
+      });
+    }
+
+    const supabase = createClient(SUPABASE_URL, SUPABASE_SERVICE_ROLE);
+    const results: OcrResult[] = [];
+    const logs: string[] = [];
+
+    for (const file of files) {
+      const { fileName, publicUrl, mimeType } = file as {
+        fileName: string;
+        publicUrl: string;
+        mimeType?: string;
+      };
+
+      const response: OcrResult = {
+        fileName,
+        pageCount: 0,
+        wordsPerPage: [],
+        detectedLanguage: "undetermined",
+        totalWordCount: 0,
+        complexity: "medium",
+        ocrStatus: "error",
+        ocrMessage: "Unknown error",
+      };
+
+      const fileExt = fileName.split(".").pop()?.toLowerCase() || "";
+      const fileToken = crypto
+        .createHash("sha1")
+        .update(`${quote_id}:${fileName}`)
+        .digest("hex");
+      const routeBase = (mimeType || fileName).toLowerCase().includes("pdf")
+        ? "pdf-digital"
+        : "image-ocr";
+
+      let buffer: Buffer | null = null;
+
+      try {
+        const download = await fetch(publicUrl);
+        if (!download.ok) {
+          throw new Error(`Download failed with status ${download.status}`);
+        }
+        buffer = Buffer.from(await download.arrayBuffer());
+        const lower = (mimeType || fileName).toLowerCase();
+
+        if (lower.includes("pdf")) {
+          const parsed = await pdfParse(buffer);
+          const pages: string[] = parsed.text.split(/\f/g);
+          const wordsPerPage = pages.map((page) => countWords(page));
+          const totalWords = wordsPerPage.reduce((sum, value) => sum + value, 0);
+
+          response.pageCount = parsed.numpages || pages.length;
+          response.wordsPerPage = wordsPerPage;
+          response.totalWordCount = totalWords;
+          response.detectedLanguage = "undetermined";
+          response.ocrStatus = "success";
+          response.ocrMessage = "OCR via PDF text extraction (fallback)";
+
+          const rows = wordsPerPage.map((count, index) => ({
+            quote_id,
+            file_token: fileToken,
+            file_name: fileName,
+            file_ext: fileExt,
+            storage_url: publicUrl,
+            file_bytes: buffer!.length,
+            route: "pdf-digital",
+            page_number: index + 1,
+            page_count: response.pageCount,
+            method: "digital",
+            word_count: count,
+            language: response.detectedLanguage,
+            status: "ok",
+            processed_at: new Date().toISOString(),
+          }));
+
+          try {
+            await supabase
+              .from("quote_pages")
+              .upsert(rows, { onConflict: "file_token,page_number" });
+          } catch (dbErr) {
+            console.error("[vision] quote_pages upsert failed:", dbErr);
+          }
+
+          logs.push(
+            `Inserted ${rows.length} pages (${rows.length} digital, 0 OCR) for file ${fileName}`,
+          );
+        } else {
+          const [visionResult] = await visionClient.documentTextDetection({
+            image: { content: buffer },
+          });
+          const annotation = visionResult?.fullTextAnnotation;
+          const text = annotation?.text || "";
+          const words = countWords(text);
+
+          response.pageCount = 1;
+          response.wordsPerPage = [words];
+          response.totalWordCount = words;
+          const language =
+            annotation?.pages?.[0]?.property?.detectedLanguages?.[0]?.languageCode ||
+            visionResult?.textAnnotations?.[0]?.locale ||
+            "undetermined";
+          response.detectedLanguage = language;
+          response.ocrStatus = "success";
+          response.ocrMessage = "OCR successful";
+
+          const confidence = annotation?.pages?.[0]?.confidence;
+          const rows = [
+            {
+              quote_id,
+              file_token: fileToken,
+              file_name: fileName,
+              file_ext: fileExt,
+              storage_url: publicUrl,
+              file_bytes: buffer!.length,
+              route: "image-ocr",
+              page_number: 1,
+              page_count: 1,
+              method: "ocr",
+              word_count: words,
+              language,
+              ocr_confidence: typeof confidence === "number" ? confidence * 100 : undefined,
+              status: "ok",
+              processed_at: new Date().toISOString(),
+            },
+          ];
+
+          try {
+            await supabase
+              .from("quote_pages")
+              .upsert(rows, { onConflict: "file_token,page_number" });
+          } catch (dbErr) {
+            console.error("[vision] quote_pages upsert failed:", dbErr);
+          }
+
+          logs.push("Inserted 1 pages (0 digital, 1 OCR) for file " + fileName);
+        }
+      } catch (err: any) {
+        response.ocrMessage = err?.message || "Processing failed";
+        const errorCode = err?.code || "PROCESSING_FAILED";
+        try {
+          await supabase.from("quote_pages").upsert(
+            [
+              {
+                quote_id,
+                file_token: fileToken,
+                file_name: fileName,
+                file_ext: fileExt,
+                storage_url: publicUrl,
+                file_bytes: buffer?.length || 0,
+                route: routeBase,
+                page_number: 0,
+                page_count: 0,
+                method: "error",
+                word_count: 0,
+                language: "undetermined",
+                status: "error",
+                error_code: errorCode,
+                error_message: response.ocrMessage,
+                processed_at: new Date().toISOString(),
+              },
+            ],
+            { onConflict: "file_token,page_number" },
+          );
+        } catch (dbErr) {
+          console.error("[vision] quote_pages error upsert failed:", dbErr);
+        }
+
+        logs.push(`Error: ${errorCode} for file ${fileName}`);
+      }
+
+      results.push(response);
+
+      try {
+        await supabase.from("quote_ocr_results").insert({
+          quote_id,
+          file_name: response.fileName,
+          page_count: response.pageCount,
+          words_per_page: response.wordsPerPage,
+          detected_language: response.detectedLanguage,
+          total_word_count: response.totalWordCount,
+          complexity: response.complexity,
+          ocr_status: response.ocrStatus,
+          ocr_message: response.ocrMessage,
+        });
+      } catch (dbErr) {
+        console.error("[vision] quote_ocr_results insert failed:", dbErr);
+      }
+    }
+
+    const hasSuccess = results.some((result) => result.ocrStatus === "success");
+    if (!hasSuccess) {
+      return json(500, {
+        status: "error",
+        message: "All OCR attempts failed",
+        quote_id,
+        results,
+      });
+    }
+
+    return json(200, {
+      status: "ok",
+      message: "OCR completed",
+      quote_id,
+      results,
+      logs,
+    });
+  } catch (err: any) {
+    console.error("[vision] run-vision-ocr error:", err);
+    return json(500, { status: "error", message: err?.message || String(err) });
+  }
+};
+
+export default handler;


### PR DESCRIPTION
## Summary
- add a run-gemini-analyze Netlify function that reads GOOGLE_API_KEY, logs the selected model, and returns structured JSON responses
- add a run-vision-ocr Netlify function that supports GOOGLE_APPLICATION_CREDENTIALS_JSON credentials, reuses existing OCR logic, and emits structured errors
- keep the analysis overlay open until Gemini finishes, extend signed URL TTLs, and surface backend errors in LandingPage

## Testing
- npm run typecheck *(fails: project is missing React and Google client type declarations in the existing codebase)*

------
https://chatgpt.com/codex/tasks/task_e_68c9f1c5f3988330a46028c75fb68db3